### PR TITLE
Allow mappings in request body

### DIFF
--- a/openapi/types.go
+++ b/openapi/types.go
@@ -17,6 +17,13 @@ func TypeString(typ string, format string) string {
 		return "string"
 	case "boolean":
 		return "bool"
+	case "object":
+		switch format {
+		case "map[string]string":
+			return format
+		default:
+			return "interface{}"
+		}
 	default:
 		return "interface{}"
 	}

--- a/openapi/types_test.go
+++ b/openapi/types_test.go
@@ -57,6 +57,17 @@ var typesTestTable = []struct {
 	Type:     "boolean",
 	Expected: "bool",
 }, {
+	Type:     "object",
+	Format:   "map[string]string",
+	Expected: "map[string]string",
+}, {
+	Type:     "object",
+	Format:   "map[string]RandomType",
+	Expected: "interface{}",
+}, {
+	Type:     "object",
+	Expected: "interface{}",
+}, {
 	Type:     "unknown",
 	Expected: "interface{}",
 }}


### PR DESCRIPTION
According to the OpenAPI [documentation](https://swagger.io/docs/specification/data-models/dictionaries/), we can declare mappings as
```yaml
type: object
additionalProperties: true
```

The current command does not handle this `additionalProperties` field, so we solve this problem in the PR by resorting to `format` to allow mapping for `map[string]string`.

Tested by `replace` and using for `resourceVariants` in `ua-contracts`.